### PR TITLE
add intro and "using examples" back to navigation 

### DIFF
--- a/src/main/antora/modules/ROOT/nav.adoc
+++ b/src/main/antora/modules/ROOT/nav.adoc
@@ -3,6 +3,9 @@
 
 * xref:index.adoc[]
 
+* xref:intro:overview/overview.adoc[]
+
+* xref:intro:usingexamples/usingexamples.adoc[]
 
 .Jakarta EE Core Profile
 


### PR DESCRIPTION
for #62

content was already migrated to antora before we did the chapter re-org