### PR TITLE
Remove double semicolon in the "Introduction to Jakarta Bean Validation" guide

### DIFF
--- a/src/main/antora/modules/beanvalidation/pages/bean-validation/bean-validation002.adoc
+++ b/src/main/antora/modules/beanvalidation/pages/bean-validation/bean-validation002.adoc
@@ -137,7 +137,7 @@ String message;
 [source,java]
 ----
 @NotEmpty
-String message;;
+String message;
 ----
 {empty}
 

--- a/src/main/antora/modules/beanvalidation/pages/bean-validation/bean-validation002.adoc
+++ b/src/main/antora/modules/beanvalidation/pages/bean-validation/bean-validation002.adoc
@@ -78,7 +78,7 @@ Date eventDate;
 ----
 {empty}
 
-|`@FutureOrPresent` |TThe value of the field or property must be a date or time in present or future. |
+|`@FutureOrPresent` |The value of the field or property must be a date or time in present or future. |
 
 [source,java]
 ----


### PR DESCRIPTION
I noticed a double semicolon in the `@NotEmpty` Jakarta Bean Validation usage guide.
See https://jakarta.ee/learn/docs/jakartaee-tutorial/current/beanvalidation/bean-validation/bean-validation.html#_using_jakarta_bean_validation_constraints

Closess #131

<img width="810" alt="image" src="https://github.com/user-attachments/assets/1d2e21b8-30aa-42d7-a1d6-65019ed4c5ae" />